### PR TITLE
fix error with allocation and deallocation mismatch

### DIFF
--- a/Knuth_Morris_Pratt_Algorithm/KMP.cpp
+++ b/Knuth_Morris_Pratt_Algorithm/KMP.cpp
@@ -66,7 +66,7 @@ void KMPSearch(string pattern, string text)
         }
     }
 
-    delete lps;
+    delete[] lps;
 }
 
 int main()

--- a/Z_Algorithm/Z_Algorithm.cpp
+++ b/Z_Algorithm/Z_Algorithm.cpp
@@ -51,7 +51,7 @@ void search(string text, string pattern)
         if(Z[i] == pattern.length())
             cout << "Pattern found at " <<  i - pattern.length() << endl;
 
-    delete Z;
+    delete[] Z;
 }
 
 


### PR DESCRIPTION
When we allocate an array using the new …[…] syntax, we should deallocate it using delete[]. In these cases, we needed to change delete to delete[]. If we use the wrong form of delete to match our allocation with new, we have undefined behavior. REF: http://stackoverflow.com/a/21500476

Found by https://github.com/bryongloden/cppcheck